### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/OXeu/LarkGithub/compare/v0.1.1...v0.1.2) - 2024-10-16
+
+### Added
+
+- add action support
+
+### Fixed
+
+- update title
+- null input
+
+### Other
+
+- update README.md
+- fix
+- ci
+- update action.yaml
+
 ## [0.1.1](https://github.com/OXeu/LarkGithub/compare/v0.1.0...v0.1.1) - 2024-10-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "lark-github-issue"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lark-github-issue"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "sync lark bitable to github issue"


### PR DESCRIPTION
## 🤖 New release
* `lark-github-issue`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/OXeu/LarkGithub/compare/v0.1.1...v0.1.2) - 2024-10-16

### Added

- add action support

### Fixed

- update title
- null input

### Other

- update README.md
- fix
- ci
- update action.yaml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).